### PR TITLE
fix: remove case sensitive for automatic issues tagging

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -14,6 +14,7 @@ bug:
   - caseSensitive: false
 
 documentation:
+  - documentation
   - documentación
   - docs
   - readme
@@ -24,8 +25,12 @@ documentation:
   - wiki
   - typo
   - spelling mistake
+  - caseSensitive: false
 
 enhancement:
+  - enh
+  - impr
+  - enhancement
   - mejora
   - optimizar
   - me gustaría que
@@ -38,8 +43,10 @@ enhancement:
   - performance
   - refactor
   - make better
-
+  - caseSensitive: false
+  
 feature:
+  - feat
   - nueva función
   - agregar
   - añadir
@@ -51,8 +58,10 @@ feature:
   - support for
   - extend
   - include
+  - caseSensitive: false
 
 invalid:
+  - inv
   - invalido
   - invalida
   - no válido
@@ -71,8 +80,10 @@ invalid:
   - not applicable
   - unclear
   - nonsensical
+  - caseSensitive: false
 
 question:
+  - qst
   - pregunta
   - consulta
   - preguntar
@@ -92,8 +103,10 @@ question:
   - what is
   - can someone explain
   - i don’t understand
+  - caseSensitive: false
 
 help wanted:
+  - help
   - ayuda
   - no sé cómo
   - alguien puede
@@ -104,6 +117,7 @@ help wanted:
   - anyone can help
   - looking for help
   - collaborate
+  - caseSensitive: false
 
 wontfix:
   - no se arreglará
@@ -114,8 +128,10 @@ wontfix:
   - wont fix
   - wont be addressed
   - intentional
+  - caseSensitive: false
 
 duplicate:
+  - dup
   - duplicado
   - ya existe
   - repetido
@@ -123,8 +139,11 @@ duplicate:
   - already reported
   - same issue
   - redundant
+  - caseSensitive: false
 
 good first issue:
+  - good first
+  - gfi
   - tarea sencilla
   - principiante
   - fácil de resolver
@@ -135,3 +154,4 @@ good first issue:
   - easy fix
   - beginner friendly
   - simple task
+  - caseSensitive: false

--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -11,6 +11,7 @@ bug:
   - failure
   - unexpected behavior
   - malfunction
+  - caseSensitive: false
 
 documentation:
   - documentación

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -11,7 +11,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: MaximilianAnzinger/issue-labeler@1.0.0 # Use the latest version
+      - uses: MaximilianAnzinger/issue-labeler@1.0.2 # Use the latest version
         with:
           configuration-path: .github/issue-labeler.yml
           repo-token: ${{ github.token }}


### PR DESCRIPTION
Este pull request remueve la propiedad "case sensitive" que tenía la acción que pone tags a los issues de forma automática.
Con este fix, la acción ignorará si la palabra está en mayúsculas, minúsculas, etc... De modo que si el titulo de un issue tiene "bug, Bug, bUg, BUG, etc...) sin importar como esté escrito bug, se le agregará la correspondiente etiqueta, lo mismo para los demás tags.
También mencionar que la acción agrega las etiquetas dependiendo de las palabras claves que se encuentran en el archivo "issue-labeler.yml" en la carpeta .github.
