### PR TITLE
chore: responsive & spacing update

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,21 +4,24 @@ import ImageCard from "../components/ui/image-card";
 ---
 <BaseLayout title="Hacktion">
   <main class="">
-    <section class="flex flex-col items-stretch md:flex-row w-11/12 md:w-3/5 h-auto gap-y-3 md:gap-x-3 mx-auto">
-      <div class="w-full md:w-1/2">
-        <h2 class="text-6xl">Acerca de nosotros</h2>
-        <p class="text-gray-500 font-normal">
-          Hacktion es un hackathon hecha por la comunidad de Notion Campus Leaders en colaboración
-          con muchas otras comunidades de desarrollo. <br>
-          <br>
-          Busca crear un espacio donde personas que van adentrando a la informática puedan
-          experimentar su primer hackathon aprendiendo de la mano de grandes mentores y poniendo a
-          prueba para poder resolver problemas de alto impacto
-        </p>
+    <section class="flex flex-col items-stretch lg:flex-row w-11/12 md:w-3/5 h-auto gap-y-3 md:gap-x-3 mx-auto">
+      <div class="w-full lg:w-1/2 text-center lg:text-left">
+        <h2 class="md:text-6xl text-4xl mb-2">Acerca de nosotros</h2>
+        <div class="text-gray-500 font-normal space-y-4">
+          <p>
+            Hacktion es un hackathon hecha por la comunidad de Notion Campus Leaders en colaboración
+            con muchas otras comunidades de desarrollo.
+          </p>
+          <p>
+            Busca crear un espacio donde personas que van adentrando a la informática puedan
+            experimentar su primer hackathon aprendiendo de la mano de grandes mentores y poniendo a
+            prueba para poder resolver problemas de alto impacto
+          </p>
+        </div>
       </div>
 
       <ImageCard
-        className="w-2/5 h-auto mx-auto bg-[#00823A]"
+        className="lg:w-2/5 md:w-3/5 w-full h-auto mx-auto bg-[#00823A]"
         caption="Hacktion 2024 - Wizeline CDMX"
         imageUrl="/Hacktion/bbhacktion.jpg"
       ></ImageCard>


### PR DESCRIPTION
Esta pull request contiene los cambios que se habian pedido en la PR anterior, pero que no se les había hecho el push antes del merge de la misma. Estos cambios fueron: 
- Modificaciones hechas para que la sección "Acerca de nosotros" fuera responsive (Los cambios que se ven en las últimas fotos de la PR #60 )
- Agregar un espaciado extra entre el título y el texto.
- Reemplazar los `<br>,` usando un div para los párrafos y la propiedad `space-y-4`.
- En los dispositivos pequeños, que la `Image-Card` ocupara todo el espacio que tiene para ocupar.
- Que el título en dispositivos pequeños tenga un menor tamaño.

Cualquier otra corrección o cambio quedo al pendiente c: